### PR TITLE
Updated S3 lifycycle policy for reduced data storage

### DIFF
--- a/data-exports/deploy/cur-aggregation.yaml
+++ b/data-exports/deploy/cur-aggregation.yaml
@@ -1,6 +1,6 @@
 # https://github.com/awslabs/cid-data-collection-framework/blob/main/data-exports/deploy/cur-aggregation.yaml
 AWSTemplateFormatVersion: "2010-09-09"
-Description: AWS Legacy CUR Aggregation Stack v0.1.0 - AWS Solution SO9011
+Description: AWS Legacy CUR Aggregation Stack v0.2.0 - AWS Solution SO9011
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/data-exports/deploy/cur-aggregation.yaml
+++ b/data-exports/deploy/cur-aggregation.yaml
@@ -129,7 +129,7 @@ Resources:
         Rules:
           - Id: Object&Version Expiration
             Status: Enabled
-            NoncurrentVersionExpirationInDays: 32 # 1 month
+            NoncurrentVersionExpirationInDays: 1
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -281,8 +281,8 @@ Resources:
         Rules:
           - Id: Object&Version Expiration
             Status: Enabled
-            NoncurrentVersionExpirationInDays: 32 # 1 month
-            ExpirationInDays: 64 # 2 months
+            NoncurrentVersionExpirationInDays: 1
+            ExpirationInDays: 7
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/data-exports/deploy/data-exports-aggregation.yaml
+++ b/data-exports/deploy/data-exports-aggregation.yaml
@@ -1,6 +1,6 @@
 # https://github.com/awslabs/cid-data-collection-framework/blob/main/data-exports/deploy/data-exports-aggregation.yaml
 AWSTemplateFormatVersion: "2010-09-09"
-Description: AWS Billing Data Export Aggregation v0.3.1 - AWS Solution SO9011
+Description: AWS Billing Data Export Aggregation v0.4.0 - AWS Solution SO9011
 Metadata:
 
   AWS::CloudFormation::Interface:

--- a/data-exports/deploy/data-exports-aggregation.yaml
+++ b/data-exports/deploy/data-exports-aggregation.yaml
@@ -224,7 +224,7 @@ Resources:
         Rules:
           - Id: Object&Version Expiration
             Status: Enabled
-            NoncurrentVersionExpirationInDays: 32 # 1 month
+            NoncurrentVersionExpirationInDays: 1
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -401,8 +401,8 @@ Resources:
         Rules:
           - Id: Object&Version Expiration
             Status: Enabled
-            NoncurrentVersionExpirationInDays: 32 # 1 month
-            ExpirationInDays: 64 # 2 months
+            NoncurrentVersionExpirationInDays: 1
+            ExpirationInDays: 7
       Tags: # Hacky way to manage conditional dependencies
         - Key: IgnoreConditionalDependency
           Value: !If [IsDestinationAccount, !Ref DestinationS3, '']


### PR DESCRIPTION
Updated `NoncurrentVersionExpirationInDays` and `ExpirationInDays` values to reduce data storage in source and destination buckets in payer/management and data collection accounts respectively.
