### PR TITLE
Delete incomplete multipart uploads and expired delete markers from S3 Buckets

### DIFF
--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -354,10 +354,11 @@ Resources:
               NoncurrentDays: 7
               NewerNoncurrentVersions: 1
             # ExpirationInDays: 365 # Set Expiration of all objects here (not recommended but can be useful in case of big workloads) 
-          - Id: DeleteIncompleteMultipartUploads
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
             Status: Enabled
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
           - Id: CleanupOldPricingFiles
             Status: Enabled
             Prefix: pricing/pricing-

--- a/data-collection/deploy/module-compute-optimizer.yaml
+++ b/data-collection/deploy/module-compute-optimizer.yaml
@@ -329,6 +329,11 @@ Resources:
                     Status: Enabled
                     NoncurrentVersionExpiration:
                       NoncurrentDays: 1
+                  - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+                    Status: Enabled
+                    AbortIncompleteMultipartUpload:
+                      DaysAfterInitiation: 7
+                    ExpiredObjectDeleteMarker: true
       Tags: # Hacky way to manage dependencies
         - Key: IgnoreMeIamOnlyWorkaround
           Value: !GetAtt StackSetExecutionRole.Arn

--- a/data-exports/deploy/cur-aggregation.yaml
+++ b/data-exports/deploy/cur-aggregation.yaml
@@ -130,6 +130,11 @@ Resources:
           - Id: Object&Version Expiration
             Status: Enabled
             NoncurrentVersionExpirationInDays: 1
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -283,6 +288,11 @@ Resources:
             Status: Enabled
             NoncurrentVersionExpirationInDays: 1
             ExpirationInDays: 7
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/data-exports/deploy/data-exports-aggregation.yaml
+++ b/data-exports/deploy/data-exports-aggregation.yaml
@@ -264,6 +264,11 @@ Resources:
           - Id: Object&Version Expiration
             Status: Enabled
             NoncurrentVersionExpirationInDays: 1
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -465,6 +470,11 @@ Resources:
             Status: Enabled
             NoncurrentVersionExpirationInDays: 1
             ExpirationInDays: 7
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
       Tags: # Hacky way to manage conditional dependencies
         - Key: IgnoreConditionalDependency
           Value: !If [IsDestinationAccount, !Ref DestinationS3, '']

--- a/security-hub/deploy/module-securityhub.yaml
+++ b/security-hub/deploy/module-securityhub.yaml
@@ -132,6 +132,11 @@ Resources:
           - Id: Object&Version Expiration
             Status: Enabled
             NoncurrentVersionExpirationInDays: 7
+          - Id: DeleteIncompleteMultipartUploadsAndExpiredDeleteMarkers
+            Status: Enabled
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+            ExpiredObjectDeleteMarker: true
       ReplicationConfiguration:
         Fn::If:
           - SendData


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This makes sure that S3 buckets with Versioning/Expiration enabled are actually emptied, and that Incomplete uploads do not stick around forever.

I added this to every "AWS::S3::Bucket" but only tested data-exports/deploy/cur-aggregation.yaml (because I'm in the process of removing that bucket)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
