### PR TITLE
Update FOCUS from 1.0 to 1.2 in data-exports-aggregation.yaml

### DIFF
--- a/data-exports/deploy/data-exports-aggregation.yaml
+++ b/data-exports/deploy/data-exports-aggregation.yaml
@@ -1,6 +1,6 @@
 # https://github.com/awslabs/cid-data-collection-framework/blob/main/data-exports/deploy/data-exports-aggregation.yaml
 AWSTemplateFormatVersion: "2010-09-09"
-Description: AWS Billing Data Export Aggregation v0.9.0 - AWS Solution SO9011
+Description: AWS Billing Data Export Aggregation v0.10.0 - AWS Solution SO9011
 Metadata:
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
- Changed query from FOCUS_1_0_AWS to FOCUS_1_2_AWS
- Added 18 new FOCUS 1.2 columns including BillingAccountType, CapacityReservation fields, InvoiceId, PricingCurrency fields, SkuPriceDetails, etc.
- Removed x_CostCategories and x_UsageType columns
- Updated Glue table schema to match FOCUS 1.2 specification

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
