### PR TITLE
fix(health-events): honor ItemsPerBatch/MaxConcurrentBatches substitutions in detail state machine

### DIFF
--- a/data-collection/deploy/source/step-functions/health-detail-state-machine.json
+++ b/data-collection/deploy/source/step-functions/health-detail-state-machine.json
@@ -91,9 +91,9 @@
           "Key": "{% $MAP_KEY %}"
         }
       },
-      "MaxConcurrency": 1,
+      "MaxConcurrency": ${MaxConcurrentBatches},
       "ItemBatcher": {
-        "MaxItemsPerBatch": 500,
+        "MaxItemsPerBatch": ${ItemsPerBatch},
         "BatchInput": {
           "account": "{% $ACCOUNT %}",
           "ingestion_time": "{% $INGEST_TIME %}",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

The AWS Health events **detail** state machine
(`data-collection/deploy/source/step-functions/health-detail-state-machine.json`)
hardcoded its Distributed Map batching config:

```json
"MaxConcurrency": 1,
"ItemBatcher": {
  "MaxItemsPerBatch": 500,
```

However, `module-health-events.yaml` passes `ItemsPerBatch: 50` and
`MaxConcurrentBatches: 1` as `DefinitionSubstitutions` on the `StepFunctionDetail`
resource. Because the ASL never referenced `${ItemsPerBatch}` /
`${MaxConcurrentBatches}`, those substitutions were silently ignored and the
effective batch size was always 500.

**Impact:** The detail Lambda (`Timeout: 900`, `MemorySize: 2688`) receives up to
500 event ARNs per invocation and processes them serially — each event fans out
into multiple paginated AWS Health Organizational API calls
(`describe_affected_accounts_for_organization`,
`describe_event_details_for_organization`,
`describe_affected_entities_for_organization`). On large or first-run/backfill
collections (`LOOKBACK: 730`), heavy batches exceed the 900s Lambda hard limit and
time out. Because the failing batch never completes, the incremental checkpoint
logic in `calculate_dates()` never advances, so the module can get stuck
re-attempting the same oversized batch on every run.

**Fix:** Wire the two values to the existing substitutions so the intended
configuration in `module-health-events.yaml` actually takes effect (batch size
500 → 50) and becomes tunable without editing the ASL. This matches the existing
unquoted-substitution pattern already used in the same file (`"CRAWLERS": ${Crawlers}`).

```diff
-      "MaxConcurrency": 1,
+      "MaxConcurrency": ${MaxConcurrentBatches},
       "ItemBatcher": {
-        "MaxItemsPerBatch": 500,
+        "MaxItemsPerBatch": ${ItemsPerBatch},
```

**Validation:** Mock-rendered the `${...}` substitution tokens and confirmed the
result parses as valid JSON. No behavioral change to the Lambda code or schema;
only the Distributed Map batching parameters now respect the template substitutions.

**Possible follow-ups (not in this PR, to keep it focused):**
- Surface `ItemsPerBatch` / `MaxConcurrentBatches` (and `LOOKBACK`) as CloudFormation
  parameters in `module-health-events.yaml` + `deploy-data-collection.yaml` so
  operators (incl. Terraform users) can tune them without forking templates.
- Add `ToleratedFailurePercentage` to the Map so a single heavy batch cannot block
  checkpoint advancement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.