### PR TITLE
Add instances details module to fetch latest instances for the KPI da…

### DIFF
--- a/data-collection/README.md
+++ b/data-collection/README.md
@@ -45,6 +45,7 @@ List of modules and objects collected:
 | `resilience-hub`                 |   [AWS Resilince Hub](https://aws.amazon.com/resilience-hub/) | Linked Accounts |  |
 | `marketplace`                 |   [AWS Marketplace](https://aws.amazon.com/marketplace/) | Linked Accounts | Collects AWS Marketplace data and terms |
 | `reference`                 |   Various services      | Data Collection Account | Collects reference data for other modules and dashboard to function |
+| `instances-details`                 |   Various services      | Data Collection Account | Collects EC2, RDS, ElastiCache, and OpenSearch available instances details |
 
 ### Deployment Overview
 

--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -44,6 +44,7 @@ Metadata:
           - IncludeIdentityCenterModule
           - IncludeMarketplaceModule
           - IncludeReferenceModule          
+          - IncludeInstancesDetailsModule
       - Label:
           default: 'EUC (End User Compute) Module Configuration'
         Parameters:
@@ -117,6 +118,8 @@ Metadata:
         default: 'Include Identity Center Data Collection Module'
       IncludeMarketplaceModule:
         default: 'Include Marketplace Data Collection Module'
+      IncludeInstancesDetailsModule:
+        default: 'Include Instances Details Data Collection Module'
 
 Mappings:
   RegionMap:
@@ -311,6 +314,11 @@ Parameters:
     Description: Collects Reference data for other modules
     AllowedValues: ['yes', 'no']
     Default: 'no'
+  IncludeInstancesDetailsModule:
+    Type: String
+    Description: Collects instances details data
+    AllowedValues: ['yes', 'no']
+    Default: 'no'
 Conditions:
   DeployTAModule: !Equals [ !Ref IncludeTAModule, "yes"]
   DeployRightsizingModule: !Equals [ !Ref IncludeRightsizingModule, "yes"]
@@ -335,6 +343,7 @@ Conditions:
   DeployMarketplaceModule: !Equals [ !Ref IncludeMarketplaceModule, "yes"]
   DeployIdentityCenterModule: !Equals [ !Ref IncludeIdentityCenterModule, "yes"]
   DeployBoto3Layer: !Condition DeployHealthEventsModule
+  DeployInstancesDetailsModule: !Equals [ !Ref IncludeInstancesDetailsModule, "yes"]
   DeployPricingModule: !Or
     - !Condition DeployInventoryCollectorModule
     - !Condition DeployRDSUtilizationModule
@@ -1599,6 +1608,25 @@ Resources:
         StepFunctionExecutionRoleARN: !GetAtt StepFunctionExecutionRole.Arn
         SchedulerExecutionRoleARN: !GetAtt SchedulerExecutionRole.Arn
         LambdaManageGlueTableARN: !GetAtt LambdaManageGlueTable.Arn
+
+  InstancesDetailsModule:
+    Type: AWS::CloudFormation::Stack
+    Condition: DeployInstancesDetailsModule
+    Properties:
+      TemplateURL: !Sub "https://${CFNSourceBucket}.s3.${AWS::URLSuffix}/cfn/data-collection/v3.14.5/module-instances-details.yaml"
+      Parameters:
+        DatabaseName: !Ref DatabaseName
+        DestinationBucket: !Ref S3Bucket
+        DestinationBucketARN: !GetAtt S3Bucket.Arn
+        DataBucketsKmsKeysArns: !Ref DataBucketsKmsKeysArns
+        Schedule: !Ref ScheduleFrequent
+        GlueRoleARN: !GetAtt GlueRole.Arn
+        ResourcePrefix: !Ref ResourcePrefix
+        LambdaAnalyticsARN: !GetAtt LambdaAnalytics.Arn
+        CodeBucket: !If [ ProdCFNTemplateUsed, !FindInMap [RegionMap, !Ref "AWS::Region", CodeBucket], !Ref CFNSourceBucket ]
+        StepFunctionTemplate: !FindInMap [StepFunctionCode, standalone-state-machine, TemplatePath]
+        StepFunctionExecutionRoleARN: !GetAtt StepFunctionExecutionRole.Arn
+        SchedulerExecutionRoleARN: !GetAtt SchedulerExecutionRole.Arn
 
   ReferenceModule:
     Type: AWS::CloudFormation::Stack

--- a/data-collection/deploy/module-instances-details.yaml
+++ b/data-collection/deploy/module-instances-details.yaml
@@ -1,0 +1,559 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Retrieves EC2, RDS, ElastiCache, and ElasticSearch instance data for the KPI dashboard in Data Collection Account only
+Parameters:
+  DatabaseName:
+    Type: String
+    Description: Name of the Athena database to be created to hold lambda information
+    Default: optimization_data
+  DestinationBucket:
+    Type: String
+    Description: Name of the S3 Bucket to be created to hold data information
+    AllowedPattern: (?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)
+  DestinationBucketARN:
+    Type: String
+    Description: ARN of the S3 Bucket that exists or needs to be created to hold rightsizing information
+  CFDataName:
+    Type: String
+    Description: The name of what this cf is doing.
+    Default: instances-details
+  GlueRoleARN:
+    Type: String
+    Description: Arn for the Glue Crawler role
+  Schedule:
+    Type: String
+    Description: EventBridge Schedule to trigger the data collection
+    Default: "rate(14 days)"
+  ResourcePrefix:
+    Type: String
+    Description: This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable
+  LambdaAnalyticsARN:
+    Type: String
+    Description: Arn of lambda for Analytics
+  CodeBucket:
+    Type: String
+    Description: Source code bucket
+  StepFunctionTemplate:
+    Type: String
+    Description: S3 key to the JSON template for the StepFunction
+  StepFunctionExecutionRoleARN:
+    Type: String
+    Description: Common role for Step Function execution
+  SchedulerExecutionRoleARN:
+    Type: String
+    Description: Common role for module Scheduler execution
+  DataBucketsKmsKeysArns:
+    Type: String
+    Description: "ARNs of KMS Keys for data buckets and/or Glue Catalog. Comma separated list, no spaces. Keep empty if data Buckets and Glue Catalog are not Encrypted with KMS. You can also set it to '*' to grant decrypt permission for all the keys."
+    Default: ""
+
+Conditions:
+  NeedDataBucketsKms: !Not [ !Equals [ !Ref DataBucketsKmsKeysArns, "" ] ]
+
+Outputs:
+  StepFunctionARN:
+    Description: ARN for the module's Step Function
+    Value: !GetAtt ModuleStepFunction.Arn
+
+Resources: 
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ResourcePrefix}${CFDataName}-LambdaRole"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub "lambda.${AWS::URLSuffix}"
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Path: /
+      Policies:
+        - !If
+          - NeedDataBucketsKms
+          - PolicyName: "KMS"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: "Allow"
+                  Action:
+                    - "kms:GenerateDataKey"
+                  Resource: !Split [ ',', !Ref DataBucketsKmsKeysArns ]
+          - !Ref AWS::NoValue
+        - PolicyName: "InstancesAccess"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "pricing:GetProducts"
+                  - "ec2:DescribeInstanceTypes"
+                Resource: "*"
+        - PolicyName: "S3Access"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:PutObject"
+                Resource:
+                  - !Sub "${DestinationBucketARN}/*"
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28 # Resource found with an explicit name, this disallows updates that require replacement of this resource
+            reason: "Need explicit name to identify role actions"
+          - id: W12
+            reason: "Policy is used for scanning of a wide range of resources"
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${ResourcePrefix}${CFDataName}-Lambda'
+      Description: !Sub "Lambda function to retrieve ${CFDataName}"
+      Runtime: python3.13
+      Architectures: [x86_64]
+      Timeout: 900
+      Role: !GetAtt LambdaRole.Arn
+      Environment:
+        Variables:
+          BUCKET_NAME: !Ref DestinationBucket
+          PREFIX: !Ref CFDataName
+          LOG_LEVEL: INFO
+      Code:
+        ZipFile: |
+            """
+            Lambda to collect Instance Details information to the local data collection account
+            Author: Alessandro Russo
+            """
+            import os
+            import json
+            import logging
+            import re
+            from json import JSONEncoder
+            from typing import Dict, List
+            from datetime import datetime
+            import boto3
+
+
+            #Environment Variables
+            BUCKET = os.environ["BUCKET_NAME"]
+            PREFIX = os.environ["PREFIX"]
+            TARGET_FILE = "kpi_instance_mapping_view.json"
+            TMP_FILE = "/tmp/"+TARGET_FILE
+            KEY = datetime.now().strftime(f"{PREFIX}/{PREFIX}-data/year=%Y/month=%m/day=%d/{TARGET_FILE}")
+
+            logger = logging.getLogger(__name__)
+            logger.setLevel(getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper(), logging.INFO))
+
+            class DateTimeEncoder(JSONEncoder):
+                """encoder for json with time object"""
+                def default(self, o):
+                    if isinstance(o, datetime):
+                        return o.isoformat()
+                    return None
+
+            class KPI_Instances:
+                def __init__(self):
+                    self.ec2_client = boto3.client('ec2', region_name='us-east-1')
+                    self.pricing_client = boto3.client('pricing', region_name='us-east-1')
+
+                def _get_processor_architecture(self, instance: Dict) -> str:
+                    if 'ProcessorInfo' in instance and 'Manufacturer' in instance['ProcessorInfo']:
+                        match instance['ProcessorInfo']['Manufacturer']:
+                            case "Intel":
+                                return "Intel"
+                            case "AMD":
+                                return "AMD"
+                            case "AWS":
+                                return "Graviton"
+                            case _:
+                                return "Unknown"
+                    return "Unknown"
+
+                def _get_processor_architecture_by_instance(self, instance: str) -> str:
+                    generation_number = self._get_generation_number(instance)
+                    suffix = instance.split(str(generation_number),3)[1]
+                    if instance.startswith("om") or instance.startswith("or"):
+                        return "Unknown"
+                    elif suffix == "" or suffix.startswith("i"):
+                        return "Intel"
+                    elif suffix[0].startswith("a"):
+                        return "AMD"
+                    elif suffix[0].startswith("g"):
+                        return "Graviton"
+                    else:
+                        return "Intel"
+
+                def _get_generation_number(self, instance_type: str) -> int:
+                    generation = re.findall(r'\d+', instance_type)
+                    return int(generation[0]) if generation else 0
+
+                def _getLatestProcessor(self, instance_c: str, architecture: str, instance_families: List[Dict]) -> str:
+                    try:
+                        generation_number = self._get_generation_number(instance_c)
+                        family_c = instance_c.split(str(generation_number),3)[0]
+                        suffix_c = instance_c.split(str(generation_number),3)[1]
+                        latest = ""
+                        for instance, data in list(instance_families.items()):
+                            if instance == instance_c or data['family'] != family_c or data['instance_processor'] != architecture or data['generation_number'] <= generation_number:
+                                continue
+                            elif re.sub("[iag]","",data['suffix']) != re.sub("[iag]","",suffix_c):
+                                continue
+                            elif len(re.sub("[iag]","",data['suffix']))>len(suffix_c):
+                                continue
+                            else:
+                                latest = str(instance)
+                            if latest != "":
+                                break
+                        return latest
+                    except Exception as e:
+                        logger.error("Error _getLatestProcessor for %s for %s : %s", instance_c , architecture, str(e))
+                        return []
+
+                def _getPreviousProcessor(self, instance_c: str, architecture: str, instance_families: List[Dict]) -> str:
+                    generation_number = self._get_generation_number(instance_c)
+                    family_c = instance_c.split(str(generation_number),3)[0]
+                    suffix_c = instance_c.split(str(generation_number),3)[1]
+                    for instance, data in list(instance_families.items()):
+                        if instance == instance_c or data['family'] != family_c or data['generation_number'] >= generation_number or data['instance_processor'] != architecture or re.sub("[iag]","",data['suffix']) != re.sub("[iag]","",suffix_c):
+                            continue
+                        return str(instance)
+                    return ""
+
+                def _get_ec2_instances_for_region(self, region: str) -> List[Dict]:
+                    try:
+                        # First collect the EC2 instances
+                        paginator = self.ec2_client.get_paginator('describe_instance_types')
+                        instance_families = {}
+                        logger.info("Collecting EC2 instance generations for %s...", region)
+                        for page in paginator.paginate():
+                            for instance in page['InstanceTypes']:
+                                instance_type = instance['InstanceType']
+                                instance_p = instance_type.split('.')[0]
+                                generation_number = self._get_generation_number(instance_p)
+                                family = instance_p.split(str(generation_number),3)[0]
+                                suffix = instance_p.split(str(generation_number),3)[1]
+                                instance_generation = "Current" if instance.get('CurrentGeneration', False) else "Previous"
+                                manufacturer = self._get_processor_architecture(instance)
+                                if instance_p not in instance_families:
+                                    instance_families[instance_p] = {
+                                        'family': family,
+                                        'suffix': suffix,
+                                        'service': 'AmazonEC2',
+                                        'generation_number': generation_number,
+                                        'generation': instance_generation,
+                                        'instance_processor': manufacturer,
+                                        'latest_intel': '',
+                                        'latest_amd': '',
+                                        'latest_graviton': '',
+                                        'previous_intel': ''
+                                    }
+                        logger.info("Collected %d instances in %s", len(instance_families), region)
+                        logger.info("Completed processing %d EC2 instances for %s", len(instance_families), region)
+                        return instance_families
+                    except Exception as e:
+                        logger.error("Error collecting EC2 instance for region %s: %s", region, str(e))
+                        return []
+
+                def generate_ec2(self, region='us-east-1'):
+                    logger.info("Starting Amazon EC2 Instance report generation...")
+                    start_time = datetime.now()
+                    instances = self._get_ec2_instances_for_region(region)
+                    # sorting desc to match latest instances generations
+                    instances = dict(sorted(instances.items(), reverse=True))
+                    instances_cid = self._fill_instances_for_kpi('AmazonEC2', instances)
+                    end_time = datetime.now()
+                    duration = end_time - start_time
+                    logger.info("Total EC2 instances collected: %d in %s seconds", len(instances), duration)
+                    return instances_cid
+
+                def _get_service_instances(self, region='eu-east-1', service='AmazonElastiCache'):
+                    try:
+                        logger.info("Collecting %s instance generations for %s...", service, region)
+                        filters=[]
+                        match service:
+                            case "AmazonElastiCache":
+                                filters = [
+                                    {'Type': 'TERM_MATCH', 'Field': 'regionCode', 'Value': region},
+                                    {'Type': 'TERM_MATCH', 'Field': 'productFamily', 'Value': 'Cache Instance'},
+                                    {'Type': 'TERM_MATCH', 'Field': 'ServiceCode', 'Value': service}
+                                ]
+                            case "AmazonRDS":
+                                filters = [
+                                    {'Type': 'TERM_MATCH', 'Field': 'regionCode', 'Value': region},
+                                    {'Type': 'TERM_MATCH', 'Field': 'ServiceCode', 'Value': 'AmazonRDS'}
+                                ]
+                            case 'AmazonES':
+                                filters = [
+                                    {'Type': 'TERM_MATCH', 'Field': 'regionCode', 'Value': region},
+                                    {'Type': 'TERM_MATCH', 'Field': 'productFamily', 'Value': 'Amazon OpenSearch Service Instance'},
+                                    {'Type': 'TERM_MATCH', 'Field': 'ServiceCode', 'Value': service}
+                                ]
+                        service_instance_families = {}
+                        paginator = self.pricing_client.get_paginator('get_products')
+
+                        # Retrieve pricing data using pagination
+                        for page in paginator.paginate(ServiceCode=service, Filters=filters):
+                            for price_item in page['PriceList']:
+                                price_data = json.loads(price_item)
+                                attributes = price_data['product']['attributes']
+                                if 'instanceType' not in attributes:
+                                    continue
+                                instance_p=""
+                                match service:
+                                    case "AmazonElastiCache":
+                                        instance_p = attributes['instanceType'].split(".", 3)[1]
+                                    case "AmazonRDS":
+                                        raw = str(attributes['instanceTypeFamily']).lower()
+                                        # strip leading 'db.' prefix if present, skip non-instance families
+                                        if raw.startswith('db.'):
+                                            instance_p = raw[3:]
+                                        elif raw == 'serverless' or not any(c.isdigit() for c in raw):
+                                            continue
+                                        else:
+                                            instance_p = raw
+                                    case 'AmazonES':
+                                        instance_p = attributes['instanceType'].split(".", 3)[0]
+                                if service == "AmazonES" and instance_p.startswith("ultrawarm"):
+                                    continue
+                                if not instance_p or not any(c.isdigit() for c in instance_p):
+                                    continue
+                                generation_number = self._get_generation_number(instance_p)
+                                family = instance_p.split(str(generation_number),3)[0]
+                                suffix = instance_p.split(str(generation_number),3)[1]
+                                instance_generation = "Current"
+                                manufacturer = self._get_processor_architecture_by_instance(instance_p)
+                                if instance_p not in service_instance_families:
+                                    service_instance_families[instance_p] = {
+                                        'family': family,
+                                        'suffix': suffix,
+                                        'service': service,
+                                        'generation_number': generation_number,
+                                        'generation': instance_generation,
+                                        'instance_processor': manufacturer,
+                                        'latest_intel': '',
+                                        'latest_amd': '',
+                                        'latest_graviton': '',
+                                        'previous_intel': ''
+                                    }
+                        return service_instance_families
+                    except Exception as e:
+                        logger.error("Error retrieving %s pricing: %s", service, str(e))
+                        return []
+
+                def _fill_instances_for_kpi(self, service, instance_families: List[Dict]) -> List[Dict]:
+                    try:
+                        # Second fill the dict with additional data
+                        logger.info("Processing %d %s instances for KPI", len(instance_families), service)
+                        instance_cid = {}
+                        for instance, data in list(instance_families.items()):
+                            if instance not in instance_cid:
+                                instance_cid[instance] = data
+                            if service == 'AmazonEC2' and data['family'] not in ["t", "r", "m", "i", "hs", "cr","cc", "c", "d","g","p"]:
+                                continue
+                            data['latest_intel'] = self._getLatestProcessor(instance, "Intel", instance_families)
+                            data['latest_amd'] = self._getLatestProcessor(instance, "AMD", instance_families)
+                            data['latest_graviton'] = self._getLatestProcessor(instance, "Graviton", instance_families)
+                            data['previous_intel'] = self._getPreviousProcessor(instance, "Intel", instance_families)
+                            match data['instance_processor']:
+                                case "Intel":
+                                    data['generation'] = "Current" if data['latest_intel'] == "" else "Previous"
+                                case "AMD":
+                                    data['generation'] = "Current" if data['latest_amd'] == "" else "Previous"
+                                case "Graviton":
+                                    data['generation'] = "Current" if data['latest_graviton'] == "" else "Previous"
+                                case _:
+                                    data['generation'] = "Previous"
+                        return instance_cid
+                    except Exception as e:
+                        logger.error("Error processing %s _fill_instances_for_kpi: %s", service, str(e))
+                        return []
+
+                def generate_service(self, region='us-east-1', service='AmazonElastiCache'):
+                    logger.info("Starting %s instance report generation...", service)
+                    start_time = datetime.now()
+                    instances = self._get_service_instances(region, service)
+                    instances = dict(sorted(instances.items(), reverse=True))
+                    instances_cid = self._fill_instances_for_kpi(service, instances)
+
+                    end_time = datetime.now()
+                    duration = end_time - start_time
+                    logger.info("Total %s instances collected: %d in %s seconds", service, len(instances), duration)
+                    return instances_cid
+
+            def lambda_handler(event, context): #pylint: disable=W0613
+                try:
+                    logger.info("Starting main execution...")
+                    kpi_generator = KPI_Instances()
+                    # Generate report for us-east-1 only, without filters
+                    logger.info(">> Retrieving EC2 Instances")
+                    instances_ec2 = kpi_generator.generate_ec2('us-east-1')
+                    # instances_ec2 = dict(sorted(instances_ec2.items(), reverse=False))
+                    instances_all = dict(sorted(instances_ec2.items(), reverse=False))
+                    logger.info(">> Retrieving AmazonElastiCache Instances")
+                    instances_ec = kpi_generator.generate_service('us-east-1','AmazonElastiCache')
+                    instances_all |=  dict(sorted(instances_ec.items(), reverse=False))
+                    logger.info(">> Retrieving AmazonRDS Instances")
+                    instances_rds = kpi_generator.generate_service('us-east-1','AmazonRDS')
+                    instances_all |= dict(sorted(instances_rds.items(), reverse=False))
+                    logger.info(">> Retrieving AmazonES Instances")
+                    instances_es = kpi_generator.generate_service('us-east-1','AmazonES')
+                    instances_all |= dict(sorted(instances_es.items(), reverse=False))
+
+                    logger.info(">> Creating file %s", TMP_FILE)
+                    with open(TMP_FILE, 'w', encoding='utf-8') as f:
+                        for instance, data in list(instances_all.items()):
+                            body = {
+                                'family': instance,
+                                'service': data['service'],
+                                'generation': data['generation'],
+                                'instance_processor': data['instance_processor'],
+                                'latest_intel': data['latest_intel'],
+                                'latest_amd': data['latest_amd'],
+                                'latest_graviton': data['latest_graviton'],
+                                'previous_intel': data['previous_intel']
+                            }
+                            f.write(json.dumps(body, cls=DateTimeEncoder) + "\n")
+
+                    logger.info(">> Instance Details Data Uploading file %s to %s/%s", TMP_FILE, BUCKET, KEY)
+                    boto3.client('s3').upload_file(TMP_FILE,BUCKET,KEY)
+                    logger.info(">> Removing %s", TMP_FILE)
+                    os.remove(TMP_FILE)
+                    logger.info(">> All done.")
+
+                except Exception as e:
+                    logger.error("Error in main execution: %s", str(e))
+                    raise
+                
+                finally:
+                  if os.path.exists(TMP_FILE):
+                      try:
+                          os.remove(TMP_FILE)
+                      except OSError as e:
+                          logger.warning("Could not delete temporary file %s: %s", TMP_FILE, e)
+                          
+      Handler: 'index.lambda_handler'
+      MemorySize: 2688
+
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89 # Lambda functions should be deployed inside a VPC
+            reason: "No need for VPC in this case"
+          - id: W92 #  Lambda functions should define ReservedConcurrentExecutions to reserve simultaneous executions
+            reason: "No need for simultaneous execution"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaFunction}"
+      RetentionInDays: 60
+
+  ModuleStepFunction:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub '${ResourcePrefix}${CFDataName}-StateMachine'
+      StateMachineType: STANDARD
+      RoleArn: !Ref StepFunctionExecutionRoleARN
+      DefinitionS3Location:
+        Bucket: !Ref CodeBucket
+        Key: !Ref StepFunctionTemplate
+      DefinitionSubstitutions:
+        ModuleLambdaARN: !GetAtt LambdaFunction.Arn
+        Crawler: !Sub '${ResourcePrefix}${CFDataName}-Crawler'
+
+  ModuleRefreshSchedule:
+    Type: 'AWS::Scheduler::Schedule'
+    Properties:
+      Description: !Sub 'Scheduler for the ODC ${CFDataName} module'
+      Name: !Sub '${ResourcePrefix}${CFDataName}-RefreshSchedule'
+      ScheduleExpression: !Ref Schedule
+      State: ENABLED
+      FlexibleTimeWindow:
+        MaximumWindowInMinutes: 30
+        Mode: 'FLEXIBLE'
+      Target:
+        Arn: !GetAtt ModuleStepFunction.Arn
+        RoleArn: !Ref SchedulerExecutionRoleARN
+
+  AnalyticsExecutor:
+    Type: Custom::LambdaAnalyticsExecutor
+    Properties:
+      ServiceToken: !Ref LambdaAnalyticsARN
+      Name: !Ref CFDataName
+
+  Crawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Name: !Sub '${ResourcePrefix}${CFDataName}-Crawler'
+      Role: !Ref GlueRoleARN
+      DatabaseName: !Ref DatabaseName
+      Targets:
+        S3Targets:
+          - Path: !Sub "s3://${DestinationBucket}/${CFDataName}/${CFDataName}-data/"
+      Configuration: |
+        {
+          "Version": 1.0,
+          "CrawlerOutput": {
+            "Partitions": {
+              "AddOrUpdateBehavior": "InheritFromTable"
+            },
+            "Tables": {
+              "AddOrUpdateBehavior": "MergeNewColumns"
+            }
+          }
+        }
+      SchemaChangePolicy:
+        UpdateBehavior: UPDATE_IN_DATABASE
+        DeleteBehavior: LOG
+  InstancesDetailsTable:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseName: !Ref DatabaseName
+      TableInput:
+        Name: 'instances_details'
+        TableType: EXTERNAL_TABLE
+        Parameters:
+          EXTERNAL: "TRUE"
+          classification: "json"
+          typeOfData: "file"
+          UPDATED_BY_CRAWLER: !Ref Crawler
+        StorageDescriptor:
+          Location: !Sub "s3://${DestinationBucket}/${CFDataName}/${CFDataName}-data/"
+          InputFormat: "org.apache.hadoop.mapred.TextInputFormat"
+          OutputFormat: "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+          SerdeInfo:
+            SerializationLibrary: "org.openx.data.jsonserde.JsonSerDe"
+            Parameters:
+              paths: "family,service,generation,instance_processor,latest_intel,latest_amd,latest_graviton,previous_intel"
+          Columns:
+            - Name: family
+              Type: string
+            - Name: service
+              Type: string
+            - Name: generation
+              Type: string
+            - Name: instance_processor
+              Type: string
+            - Name: latest_intel
+              Type: string
+            - Name: latest_amd
+              Type: string
+            - Name: latest_graviton
+              Type: string
+            - Name: previous_intel
+              Type: string
+        PartitionKeys:
+          - Name: year
+            Type: string
+          - Name: month
+            Type: string
+          - Name: day
+            Type: string

--- a/test/test_from_scratch.py
+++ b/test/test_from_scratch.py
@@ -272,6 +272,10 @@ def test_marketplace_data(athena): #marketplace - specific
     data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."agreements" LIMIT 10;')
     assert len(data) > 0, 'marketplace data is empty'
 
+def test_instances_details_data(athena):
+    data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."instances_details" LIMIT 10;')
+    assert len(data) > 0, 'instances_details is empty'
+
 def test_content_of_summary_not_empty(s3):
     s3_client = boto3.client('s3')
     case_data = {

--- a/test/utils.py
+++ b/test/utils.py
@@ -251,6 +251,7 @@ def initial_deploy_stacks(cloudformation, account_id, org_unit_id, bucket):
             {'ParameterKey': 'IncludeMarketplaceModule',        'ParameterValue': "yes"},
             {'ParameterKey': 'IncludeReferenceModule',          'ParameterValue': "yes"},
             {'ParameterKey': 'IncludeIdentityCenterModule',     'ParameterValue': "yes"},
+            {'ParameterKey': 'IncludeInstancesDetailsModule',   'ParameterValue': "yes"},
         ]
     )
 
@@ -430,6 +431,7 @@ def trigger_update(account_id):
         f"arn:{partition}:states:{region}:{account_id}:stateMachine:{PREFIX}marketplace-StateMachine",
         f"arn:{partition}:states:{region}:{account_id}:stateMachine:{PREFIX}reference-StateMachine",
         f"arn:{partition}:states:{region}:{account_id}:stateMachine:{PREFIX}identity-center-StateMachine",
+        f"arn:{partition}:states:{region}:{account_id}:stateMachine:{PREFIX}instances-details-StateMachine",
     ]
     lambda_arns = []
     lambda_norun_arns = []


### PR DESCRIPTION
## Summary
Adds a new `instances-details` data collection module that collects instance family generation data for EC2, RDS, ElastiCache, and OpenSearch. This data powers the KPI instance mapping view for identifying current vs previous generation instances and their upgrade paths (Intel, AMD, Graviton).

Related: aws-solutions-library-samples/cloud-intelligence-dashboards-framework#1211

## Changes
- `data-collection/deploy/module-instances-details.yaml` — new module (standalone pattern)
- `data-collection/deploy/deploy-data-collection.yaml` — integration wiring
- `data-collection/README.md` — module documentation
- `test/utils.py` — test integration

## Testing
- Deployed and tested in account 820497879078
- Step Function: SUCCEEDED
- Athena table `instances_details`: 184 rows across 4 services
- All existing modules unaffected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
