### PR TITLE
Add IAM credentials report data collector

### DIFF
--- a/data-collection/README.md
+++ b/data-collection/README.md
@@ -44,6 +44,7 @@ List of modules and objects collected:
 | `quicksight`                 |  [Amazon QuickSight](https://aws.amazon.com/quicksight/)    | Data Collection Account | Collects QuickSight User and Group information in the Data Collection Account only |
 | `resilience-hub`                 |   [AWS Resilince Hub](https://aws.amazon.com/resilience-hub/) | Linked Accounts |  |
 | `marketplace`                 |   [AWS Marketplace](https://aws.amazon.com/marketplace/) | Linked Accounts | Collects AWS Marketplace data and terms |
+| `iam-credential-report`      | [AWS IAM](https://aws.amazon.com/iam/) | Linked Accounts | Collects IAM credential report CSV snapshots for Athena and QuickSight |
 | `reference`                 |   Various services      | Data Collection Account | Collects reference data for other modules and dashboard to function |
 
 ### Deployment Overview

--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -42,6 +42,7 @@ Metadata:
           - IncludeEUCUtilizationModule
           - IncludeResilienceHubModule
           - IncludeIdentityCenterModule
+          - IncludeIamCredentialReportModule
           - IncludeMarketplaceModule
           - IncludeReferenceModule          
       - Label:
@@ -115,6 +116,8 @@ Metadata:
         default: 'Include Resilience Hub Data Collection Module'
       IncludeIdentityCenterModule:
         default: 'Include Identity Center Data Collection Module'
+      IncludeIamCredentialReportModule:
+        default: 'Include IAM Credential Report Data Collection Module'
       IncludeMarketplaceModule:
         default: 'Include Marketplace Data Collection Module'
 
@@ -305,6 +308,11 @@ Parameters:
     Description: Collects AWS Identity Center data
     AllowedValues: ['yes', 'no']
     Default: 'no'
+  IncludeIamCredentialReportModule:
+    Type: String
+    Description: Collects IAM credential reports from linked accounts
+    AllowedValues: ['yes', 'no']
+    Default: 'no'
 
   IncludeReferenceModule:
     Type: String
@@ -334,6 +342,7 @@ Conditions:
   DeployResilienceHubModule: !Equals [ !Ref IncludeResilienceHubModule, "yes"]
   DeployMarketplaceModule: !Equals [ !Ref IncludeMarketplaceModule, "yes"]
   DeployIdentityCenterModule: !Equals [ !Ref IncludeIdentityCenterModule, "yes"]
+  DeployIamCredentialReportModule: !Equals [ !Ref IncludeIamCredentialReportModule, "yes"]
   DeployBoto3Layer: !Condition DeployHealthEventsModule
   DeployPricingModule: !Or
     - !Condition DeployInventoryCollectorModule
@@ -361,7 +370,9 @@ Conditions:
       - !Condition DeployServiceQuotasModule
       - !Condition DeployEUCUtilizationModule
       - !Condition DeployComputeOptimizerModule
+    - !Or
       - !Condition DeployIdentityCenterModule
+      - !Condition DeployIamCredentialReportModule
   RegionsInScopeIsEmpty: !Equals
     - !Join [ '', !Split [ ' ', !Ref RegionsInScope  ] ] # remove spaces
     - ""
@@ -1599,6 +1610,27 @@ Resources:
         StepFunctionExecutionRoleARN: !GetAtt StepFunctionExecutionRole.Arn
         SchedulerExecutionRoleARN: !GetAtt SchedulerExecutionRole.Arn
         LambdaManageGlueTableARN: !GetAtt LambdaManageGlueTable.Arn
+
+  IamCredentialReportModule:
+    Type: AWS::CloudFormation::Stack
+    Condition: DeployIamCredentialReportModule
+    Properties:
+      TemplateURL: !Sub "https://${CFNSourceBucket}.s3.${AWS::URLSuffix}/cfn/data-collection/v3.14.5/module-iam-credential-report.yaml"
+      Parameters:
+        DatabaseName: !Ref DatabaseName
+        DataBucketsKmsKeysArns: !Ref DataBucketsKmsKeysArns
+        DestinationBucket: !Ref S3Bucket
+        DestinationBucketARN: !GetAtt S3Bucket.Arn
+        GlueRoleARN: !GetAtt GlueRole.Arn
+        MultiAccountRoleName: !Sub "${ResourcePrefix}${MultiAccountRoleName}"
+        Schedule: !Ref ScheduleFrequent
+        ResourcePrefix: !Ref ResourcePrefix
+        LambdaAnalyticsARN: !GetAtt LambdaAnalytics.Arn
+        AccountCollectorLambdaARN: !Sub "${AccountCollector.Outputs.LambdaFunctionARN}"
+        CodeBucket: !If [ ProdCFNTemplateUsed, !FindInMap [RegionMap, !Ref "AWS::Region", CodeBucket], !Ref CFNSourceBucket ]
+        StepFunctionTemplate: !FindInMap [StepFunctionCode, main-state-machine, TemplatePath]
+        StepFunctionExecutionRoleARN: !GetAtt StepFunctionExecutionRole.Arn
+        SchedulerExecutionRoleARN: !GetAtt SchedulerExecutionRole.Arn
 
   ReferenceModule:
     Type: AWS::CloudFormation::Stack

--- a/data-collection/deploy/deploy-data-read-permissions.yaml
+++ b/data-collection/deploy/deploy-data-read-permissions.yaml
@@ -34,6 +34,7 @@ Metadata:
           - IncludeServiceQuotasModule
           - IncludeResilienceHubModule
           - IncludeIdentityCenterModule
+          - IncludeIamCredentialReportModule
           - IncludeMarketplaceModule
     ParameterLabels:
       ManagementAccountRole:
@@ -84,6 +85,8 @@ Metadata:
         default: "Include ResilienceHub Module"
       IncludeIdentityCenterModule:
         default: "Include Identity Center Data Collection Module"
+      IncludeIamCredentialReportModule:
+        default: "Include IAM Credential Report Data Collection Module"
       IncludeMarketplaceModule:
         default: "Include Marketplace Agreements Module"
 
@@ -202,6 +205,11 @@ Parameters:
     Description: Collects AWS Identity Center data from your accounts
     AllowedValues: ['yes', 'no']
     Default: 'no'
+  IncludeIamCredentialReportModule:
+    Type: String
+    Description: Collects IAM credential reports from linked accounts
+    AllowedValues: ['yes', 'no']
+    Default: 'no'
   IncludeMarketplaceModule:
     Type: String
     Description: Collects Marketplace Agreement information
@@ -248,6 +256,7 @@ Resources:
         IncludeServiceQuotasModule: !Ref IncludeServiceQuotasModule
         IncludeResilienceHubModule: !Ref IncludeResilienceHubModule
         IncludeMarketplaceModule: !Ref IncludeMarketplaceModule
+        IncludeIamCredentialReportModule: !Ref IncludeIamCredentialReportModule
         
   DataCollectorOrgAccountModulesReadStackSet:
     Type: AWS::CloudFormation::StackSet
@@ -292,6 +301,8 @@ Resources:
           ParameterValue: !Ref IncludeResilienceHubModule
         - ParameterKey: IncludeMarketplaceModule
           ParameterValue: !Ref IncludeMarketplaceModule
+        - ParameterKey: IncludeIamCredentialReportModule
+          ParameterValue: !Ref IncludeIamCredentialReportModule
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !Split [",", !Ref OrganizationalUnitIds]

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -23,6 +23,7 @@ Metadata:
         - IncludeServiceQuotasModule
         - IncludeResilienceHubModule
         - IncludeMarketplaceModule
+        - IncludeIamCredentialReportModule
     ParameterLabels:
       DataCollectionAccountID:
         default: 'Data Collection Account ID'
@@ -52,6 +53,8 @@ Metadata:
         default: 'Include Resilience Hub Module'
       IncludeMarketplaceModule:
         default: 'Include Marketplace Agreements Module'
+      IncludeIamCredentialReportModule:
+        default: 'Include IAM Credential Report Data Collection Module'
 
 Parameters:
   DataCollectionAccountID:
@@ -120,6 +123,11 @@ Parameters:
     Description: Collects Marketplace Agreement data from your accounts
     AllowedValues: ['yes', 'no']
     Default: 'no'
+  IncludeIamCredentialReportModule:
+    Type: String
+    Description: Collects IAM credential reports from linked accounts
+    AllowedValues: ['yes', 'no']
+    Default: 'no'
 
 Conditions:
   IncludeTAModulePolicy:                 !Equals [!Ref IncludeTAModule, "yes"]
@@ -133,6 +141,7 @@ Conditions:
   IncludeServiceQuotasModulePolicy:      !Equals [!Ref IncludeServiceQuotasModule, "yes"]
   IncludeResilienceHubModulePolicy:      !Equals [!Ref IncludeResilienceHubModule, "yes"]
   IncludeMarketplaceModulePolicy:         !Equals [!Ref IncludeMarketplaceModule, "yes"]
+  IncludeIamCredentialReportModulePolicy: !Equals [!Ref IncludeIamCredentialReportModule, "yes"]
 
 Outputs:
   LambdaRole:
@@ -165,6 +174,7 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:iam::${DataCollectionAccountID}:role/${ResourcePrefix}service-quotas-LambdaRole"
                   - !Sub "arn:${AWS::Partition}:iam::${DataCollectionAccountID}:role/${ResourcePrefix}resilience-hub-LambdaRole"
                   - !Sub "arn:${AWS::Partition}:iam::${DataCollectionAccountID}:role/${ResourcePrefix}marketplace-LambdaRole"
+                  - !Sub "arn:${AWS::Partition}:iam::${DataCollectionAccountID}:role/${ResourcePrefix}iam-credential-report-LambdaRole"
       Path: /
     Metadata:
       cfn_nag:
@@ -476,6 +486,28 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
+  # IAM Credential Report policy
+  IamCredentialReportPolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: IncludeIamCredentialReportModulePolicy
+    Properties:
+      PolicyName: IamCredentialReportPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "iam:GenerateCredentialReport"
+              - "iam:GetCredentialReport"
+            Resource: "*" # IAM credential report actions do not support resource-level permissions
+      Roles:
+        - Ref: LambdaRole
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "IAM credential report actions require wildcard resources"
+
   # Marketplace Agreements policy
   AgreementsPolicy:
     Type: 'AWS::IAM::Policy'

--- a/data-collection/deploy/module-iam-credential-report.yaml
+++ b/data-collection/deploy/module-iam-credential-report.yaml
@@ -234,26 +234,25 @@ Resources:
             - { Name: user, Type: string }
             - { Name: arn, Type: string }
             - { Name: user_creation_time, Type: string }
-            - { Name: password_enabled, Type: string }
+            - { Name: password_enabled, Type: boolean }
             - { Name: password_last_used, Type: string }
             - { Name: password_last_changed, Type: string }
             - { Name: password_next_rotation, Type: string }
-            - { Name: mfa_active, Type: string }
-            - { Name: access_key_1_active, Type: string }
+            - { Name: mfa_active, Type: boolean }
+            - { Name: access_key_1_active, Type: boolean }
             - { Name: access_key_1_last_rotated, Type: string }
             - { Name: access_key_1_last_used_date, Type: string }
             - { Name: access_key_1_last_used_region, Type: string }
             - { Name: access_key_1_last_used_service, Type: string }
-            - { Name: access_key_2_active, Type: string }
+            - { Name: access_key_2_active, Type: boolean }
             - { Name: access_key_2_last_rotated, Type: string }
             - { Name: access_key_2_last_used_date, Type: string }
             - { Name: access_key_2_last_used_region, Type: string }
             - { Name: access_key_2_last_used_service, Type: string }
-            - { Name: cert_1_active, Type: string }
+            - { Name: cert_1_active, Type: boolean }
             - { Name: cert_1_last_rotated, Type: string }
-            - { Name: cert_2_active, Type: string }
+            - { Name: cert_2_active, Type: boolean }
             - { Name: cert_2_last_rotated, Type: string }
-            - { Name: additional_credentials_info, Type: string }
           InputFormat: org.apache.hadoop.mapred.TextInputFormat
           OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
           Location: !Sub "s3://${DestinationBucket}/${CFDataName}/"
@@ -265,7 +264,7 @@ Resources:
               escapeChar: "\\"
         PartitionKeys:
           - { Name: account_id, Type: string }
-          - { Name: report_date, Type: date }
+          - { Name: report_date, Type: string }
         Parameters:
           EXTERNAL: "TRUE"
           skip.header.line.count: "1"
@@ -330,43 +329,58 @@ Resources:
     Type: AWS::Athena::NamedQuery
     Properties:
       Database: !Ref DatabaseName
-      Description: QuickSight view for IAM credential reports with normalized date fields
-      Name: iam_credential_report_qs_view
+      Description: QuickSight current snapshot view for IAM credential reports with normalized date fields
+      Name: iam_credentials
       QueryString: !Sub |
-        CREATE OR REPLACE VIEW iam_credential_report_qs_view AS
-        WITH normalized AS (
-          SELECT
-            account_id,
-            report_date,
-            CAST(date_trunc('month', CAST(report_date AS timestamp)) AS date) AS report_month,
-            "user",
-            arn,
-            password_enabled = 'TRUE' AS password_enabled,
-            mfa_active = 'TRUE' AS mfa_active,
-            access_key_1_active = 'TRUE' AS access_key_1_active,
-            access_key_1_last_used_region,
-            access_key_1_last_used_service,
-            access_key_2_active = 'TRUE' AS access_key_2_active,
-            access_key_2_last_used_region,
-            access_key_2_last_used_service,
-            cert_1_active = 'TRUE' AS cert_1_active,
-            cert_2_active = 'TRUE' AS cert_2_active,
-            additional_credentials_info,
-            CASE WHEN user_creation_time IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(user_creation_time)) END AS user_creation_dt,
-            CASE WHEN password_last_used IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_last_used)) END AS password_last_used_dt,
-            CASE WHEN password_last_changed IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_last_changed)) END AS password_last_changed_dt,
-            CASE WHEN password_next_rotation IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_next_rotation)) END AS password_next_rotation_dt,
-            CASE WHEN access_key_1_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_1_last_rotated)) END AS access_key_1_last_rotated_dt,
-            CASE WHEN access_key_1_last_used_date IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_1_last_used_date)) END AS access_key_1_last_used_dt,
-            CASE WHEN access_key_2_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_2_last_rotated)) END AS access_key_2_last_rotated_dt,
-            CASE WHEN access_key_2_last_used_date IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_2_last_used_date)) END AS access_key_2_last_used_dt,
-            CASE WHEN cert_1_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(cert_1_last_rotated)) END AS cert_1_last_rotated_dt,
-            CASE WHEN cert_2_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(cert_2_last_rotated)) END AS cert_2_last_rotated_dt
-          FROM ${DatabaseName}.iam_credential_report_data
+        CREATE OR REPLACE VIEW "iam_credentials" AS
+        WITH
+          latest_report AS (
+           SELECT
+             account_id
+           , max(CAST(report_date AS date)) latest_report_date
+           FROM
+             ${DatabaseName}.iam_credential_report_data
+           GROUP BY account_id
+        ),
+          normalized AS (
+           SELECT
+             r.account_id
+           , r.report_date
+           , CAST(date_trunc('month', CAST(r.report_date AS timestamp)) AS date) report_month
+           , year(CAST(r.report_date AS timestamp)) report_year
+           , r."user"
+           , r.arn
+           , (lower(CAST(r.password_enabled AS varchar)) = 'true') password_enabled
+           , (lower(CAST(r.mfa_active AS varchar)) = 'true') mfa_active
+           , (lower(CAST(r.access_key_1_active AS varchar)) = 'true') access_key_1_active
+           , r.access_key_1_last_used_region
+           , r.access_key_1_last_used_service
+           , (lower(CAST(r.access_key_2_active AS varchar)) = 'true') access_key_2_active
+           , r.access_key_2_last_used_region
+           , r.access_key_2_last_used_service
+           , (lower(CAST(r.cert_1_active AS varchar)) = 'true') cert_1_active
+           , (lower(CAST(r.cert_2_active AS varchar)) = 'true') cert_2_active
+           , (CASE WHEN (CAST(r.user_creation_time AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.user_creation_time AS varchar)) AS timestamp)) END) user_creation_dt
+           , (CASE WHEN (CAST(r.password_last_used AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.password_last_used AS varchar)) AS timestamp)) END) password_last_used_dt
+           , (CASE WHEN (CAST(r.password_last_changed AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.password_last_changed AS varchar)) AS timestamp)) END) password_last_changed_dt
+           , (CASE WHEN (CAST(r.password_next_rotation AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.password_next_rotation AS varchar)) AS timestamp)) END) password_next_rotation_dt
+           , (CASE WHEN (CAST(r.access_key_1_last_rotated AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.access_key_1_last_rotated AS varchar)) AS timestamp)) END) access_key_1_last_rotated_dt
+           , (CASE WHEN (CAST(r.access_key_1_last_used_date AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.access_key_1_last_used_date AS varchar)) AS timestamp)) END) access_key_1_last_used_dt
+           , (CASE WHEN (CAST(r.access_key_2_last_rotated AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.access_key_2_last_rotated AS varchar)) AS timestamp)) END) access_key_2_last_rotated_dt
+           , (CASE WHEN (CAST(r.access_key_2_last_used_date AS varchar) IN ('N/A', 'no_information', 'not_supported', '')) THEN CAST(from_iso8601_timestamp('1970-01-01T00:00:00+00:00') AS timestamp) ELSE TRY(CAST(from_iso8601_timestamp(CAST(r.access_key_2_last_used_date AS varchar)) AS timestamp)) END) access_key_2_last_used_dt
+           FROM
+             ${DatabaseName}.iam_credential_report_data r
+           INNER JOIN latest_report l ON ((r.account_id = l.account_id) AND (CAST(r.report_date AS date) = l.latest_report_date))
         )
         SELECT
-          *,
-          CAST(date_trunc('month', access_key_1_last_used_dt) AS date) AS access_key_1_last_used_month,
-          CAST(date_trunc('month', access_key_2_last_used_dt) AS date) AS access_key_2_last_used_month,
-          CAST(date_trunc('month', password_last_used_dt) AS date) AS password_last_used_month
-        FROM normalized
+          *
+        , CAST(date_trunc('month', user_creation_dt) AS date) user_creation_month
+        , year(user_creation_dt) user_creation_year
+        , CAST(date_trunc('month', password_last_used_dt) AS date) password_last_used_month
+        , year(password_last_used_dt) password_last_used_year
+        , CAST(date_trunc('month', access_key_1_last_used_dt) AS date) access_key_1_last_used_month
+        , year(access_key_1_last_used_dt) access_key_1_last_used_year
+        , CAST(date_trunc('month', access_key_2_last_used_dt) AS date) access_key_2_last_used_month
+        , year(access_key_2_last_used_dt) access_key_2_last_used_year
+        FROM
+          normalized

--- a/data-collection/deploy/module-iam-credential-report.yaml
+++ b/data-collection/deploy/module-iam-credential-report.yaml
@@ -1,0 +1,372 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Retrieves IAM credential reports from linked accounts and stores daily CSV snapshots in S3
+Parameters:
+  DatabaseName:
+    Type: String
+    Description: Name of the Athena database to hold collected data
+    Default: optimization_data
+  DestinationBucket:
+    Type: String
+    Description: Name of the S3 bucket to hold collected data
+    AllowedPattern: (?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)
+  DestinationBucketARN:
+    Type: String
+    Description: ARN of the S3 bucket that holds collected data
+  MultiAccountRoleName:
+    Type: String
+    Description: Name of the IAM role deployed in linked accounts
+  CFDataName:
+    Type: String
+    Description: The name of what this module collects
+    Default: iam-credential-report
+  GlueRoleARN:
+    Type: String
+    Description: ARN for the Glue Crawler role
+  Schedule:
+    Type: String
+    Description: EventBridge schedule to trigger data collection
+    Default: "rate(1 day)"
+  ResourcePrefix:
+    Type: String
+    Description: This prefix will be placed in front of all resources created
+  LambdaAnalyticsARN:
+    Type: String
+    Description: ARN of lambda for Analytics
+  AccountCollectorLambdaARN:
+    Type: String
+    Description: ARN of the Account Collector Lambda
+  CodeBucket:
+    Type: String
+    Description: Source code bucket
+  StepFunctionTemplate:
+    Type: String
+    Description: S3 key to the JSON template for the StepFunction
+  StepFunctionExecutionRoleARN:
+    Type: String
+    Description: Common role for Step Function execution
+  SchedulerExecutionRoleARN:
+    Type: String
+    Description: Common role for module Scheduler execution
+  DataBucketsKmsKeysArns:
+    Type: String
+    Description: "ARNs of KMS Keys for data buckets and/or Glue Catalog. Comma separated list, no spaces. Keep empty if data Buckets and Glue Catalog are not Encrypted with KMS. You can also set it to '*' to grant decrypt permission for all the keys."
+    Default: ""
+
+Outputs:
+  StepFunctionARN:
+    Description: ARN for the module's Step Function
+    Value: !GetAtt ModuleStepFunction.Arn
+
+Conditions:
+  NeedDataBucketsKms: !Not [ !Equals [ !Ref DataBucketsKmsKeysArns, "" ] ]
+
+Resources:
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ResourcePrefix}${CFDataName}-LambdaRole"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub "lambda.${AWS::URLSuffix}"
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      Path: /
+      Policies:
+        - PolicyName: !Sub "${CFDataName}-MultiAccount-LambdaRole"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "sts:AssumeRole"
+                Resource: !Sub "arn:${AWS::Partition}:iam::*:role/${MultiAccountRoleName}"
+        - PolicyName: "S3Access"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:PutObject"
+                Resource:
+                  - !Sub "${DestinationBucketARN}/*"
+        - !If
+          - NeedDataBucketsKms
+          - PolicyName: "KMS"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: "Allow"
+                  Action:
+                    - "kms:GenerateDataKey"
+                  Resource: !Split [ ',', !Ref DataBucketsKmsKeysArns ]
+          - !Ref AWS::NoValue
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "Need explicit name to identify role actions"
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${ResourcePrefix}${CFDataName}-Lambda'
+      Description: !Sub "Lambda function to retrieve ${CFDataName}"
+      Runtime: python3.13
+      Architectures: [x86_64]
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import os
+          import time
+          from datetime import datetime, timezone
+
+          import boto3
+          from botocore.client import Config
+          from botocore.exceptions import ClientError
+
+          BUCKET = os.environ["BUCKET_NAME"]
+          PREFIX = os.environ["PREFIX"]
+          ROLE_NAME = os.environ["ROLE_NAME"]
+
+          RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "standard"})
+
+          logger = logging.getLogger(__name__)
+          logger.setLevel(getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO))
+
+          def assume_role(account_id, service, region):
+              partition = boto3.session.Session().get_partition_for_region(region_name=region)
+              creds = boto3.client("sts", region_name=region, config=RETRY_CONFIG).assume_role(
+                  RoleArn=f"arn:{partition}:iam::{account_id}:role/{ROLE_NAME}",
+                  RoleSessionName="data_collection"
+              )["Credentials"]
+              return boto3.client(
+                  service,
+                  region_name=region,
+                  aws_access_key_id=creds["AccessKeyId"],
+                  aws_secret_access_key=creds["SecretAccessKey"],
+                  aws_session_token=creds["SessionToken"],
+                  config=RETRY_CONFIG,
+              )
+
+          def get_credential_report(iam_client):
+              response = iam_client.generate_credential_report()
+              state = response.get("State")
+              if state == "FAILED":
+                  raise RuntimeError(f"GenerateCredentialReport failed: {response}")
+
+              for _ in range(24):
+                  try:
+                      return iam_client.get_credential_report()["Content"]
+                  except ClientError as exc:
+                      code = exc.response.get("Error", {}).get("Code")
+                      if code not in ("ReportInProgress", "ReportNotPresent"):
+                          raise
+                      time.sleep(5)
+
+              raise TimeoutError("IAM credential report was not ready after 120 seconds")
+
+          def lambda_handler(event, context): #pylint: disable=unused-argument
+              logger.info("Event data %s", json.dumps(event))
+              if "account" not in event:
+                  raise ValueError(
+                      "Please do not trigger this Lambda manually. "
+                      "Find the corresponding state machine in Step Functions and trigger from there."
+                  )
+
+              account = json.loads(event["account"])
+              account_id = account["account_id"]
+              report_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+              try:
+                  iam_client = assume_role(account_id, "iam", "us-east-1")
+                  report_content = get_credential_report(iam_client)
+                  key = f"{PREFIX}/account_id={account_id}/report_date={report_date}/credential_report.csv"
+                  boto3.client("s3", config=RETRY_CONFIG).put_object(
+                      Bucket=BUCKET,
+                      Key=key,
+                      Body=report_content,
+                      ContentType="text/csv",
+                  )
+                  logger.info("Stored IAM credential report at s3://%s/%s", BUCKET, key)
+              except Exception as exc: #pylint: disable=broad-exception-caught
+                  logger.warning("Failed to collect IAM credential report for %s: %s", account_id, exc)
+
+      Handler: 'index.lambda_handler'
+      MemorySize: 256
+      Timeout: 300
+      Role: !GetAtt LambdaRole.Arn
+      Environment:
+        Variables:
+          BUCKET_NAME: !Ref DestinationBucket
+          PREFIX: !Ref CFDataName
+          ROLE_NAME: !Ref MultiAccountRoleName
+
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W89
+            reason: "No need for VPC in this case"
+          - id: W92
+            reason: "No need for reserved concurrency"
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaFunction}"
+      RetentionInDays: 60
+
+  IamCredentialReportTable:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseName: !Ref DatabaseName
+      TableInput:
+        Name: iam_credential_report_data
+        TableType: EXTERNAL_TABLE
+        StorageDescriptor:
+          Columns:
+            - { Name: user, Type: string }
+            - { Name: arn, Type: string }
+            - { Name: user_creation_time, Type: string }
+            - { Name: password_enabled, Type: string }
+            - { Name: password_last_used, Type: string }
+            - { Name: password_last_changed, Type: string }
+            - { Name: password_next_rotation, Type: string }
+            - { Name: mfa_active, Type: string }
+            - { Name: access_key_1_active, Type: string }
+            - { Name: access_key_1_last_rotated, Type: string }
+            - { Name: access_key_1_last_used_date, Type: string }
+            - { Name: access_key_1_last_used_region, Type: string }
+            - { Name: access_key_1_last_used_service, Type: string }
+            - { Name: access_key_2_active, Type: string }
+            - { Name: access_key_2_last_rotated, Type: string }
+            - { Name: access_key_2_last_used_date, Type: string }
+            - { Name: access_key_2_last_used_region, Type: string }
+            - { Name: access_key_2_last_used_service, Type: string }
+            - { Name: cert_1_active, Type: string }
+            - { Name: cert_1_last_rotated, Type: string }
+            - { Name: cert_2_active, Type: string }
+            - { Name: cert_2_last_rotated, Type: string }
+            - { Name: additional_credentials_info, Type: string }
+          InputFormat: org.apache.hadoop.mapred.TextInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+          Location: !Sub "s3://${DestinationBucket}/${CFDataName}/"
+          SerdeInfo:
+            SerializationLibrary: org.apache.hadoop.hive.serde2.OpenCSVSerde
+            Parameters:
+              separatorChar: ","
+              quoteChar: '"'
+              escapeChar: "\\"
+        PartitionKeys:
+          - { Name: account_id, Type: string }
+          - { Name: report_date, Type: date }
+        Parameters:
+          EXTERNAL: "TRUE"
+          skip.header.line.count: "1"
+
+  Crawler:
+    Type: AWS::Glue::Crawler
+    Properties:
+      Name: !Sub '${ResourcePrefix}${CFDataName}-Crawler'
+      Role: !Ref GlueRoleARN
+      DatabaseName: !Ref DatabaseName
+      Targets:
+        CatalogTargets:
+          - DatabaseName: !Ref DatabaseName
+            Tables:
+              - !Ref IamCredentialReportTable
+      SchemaChangePolicy:
+        UpdateBehavior: UPDATE_IN_DATABASE
+        DeleteBehavior: LOG
+
+  ModuleStepFunction:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub '${ResourcePrefix}${CFDataName}-StateMachine'
+      StateMachineType: STANDARD
+      RoleArn: !Ref StepFunctionExecutionRoleARN
+      DefinitionS3Location:
+        Bucket: !Ref CodeBucket
+        Key: !Ref StepFunctionTemplate
+      DefinitionSubstitutions:
+        AccountCollectorLambdaARN: !Ref AccountCollectorLambdaARN
+        ModuleLambdaARN: !GetAtt LambdaFunction.Arn
+        Crawlers: !Sub '["${ResourcePrefix}${CFDataName}-Crawler"]'
+        CollectionType: 'LINKED'
+        Params: ''
+        Module: !Ref CFDataName
+        DeployRegion: !Ref AWS::Region
+        Account: !Ref AWS::AccountId
+        Prefix: !Ref ResourcePrefix
+        Bucket: !Ref DestinationBucket
+
+  ModuleRefreshSchedule:
+    Type: 'AWS::Scheduler::Schedule'
+    Properties:
+      Description: !Sub 'Scheduler for the ODC ${CFDataName} module'
+      Name: !Sub '${ResourcePrefix}${CFDataName}-RefreshSchedule'
+      ScheduleExpression: !Ref Schedule
+      State: ENABLED
+      FlexibleTimeWindow:
+        MaximumWindowInMinutes: 30
+        Mode: 'FLEXIBLE'
+      Target:
+        Arn: !GetAtt ModuleStepFunction.Arn
+        RoleArn: !Ref SchedulerExecutionRoleARN
+
+  AnalyticsExecutor:
+    Type: Custom::LambdaAnalyticsExecutor
+    Properties:
+      ServiceToken: !Ref LambdaAnalyticsARN
+      Name: !Ref CFDataName
+
+  AthenaQuery:
+    Type: AWS::Athena::NamedQuery
+    Properties:
+      Database: !Ref DatabaseName
+      Description: QuickSight view for IAM credential reports with normalized date fields
+      Name: iam_credential_report_qs_view
+      QueryString: !Sub |
+        CREATE OR REPLACE VIEW iam_credential_report_qs_view AS
+        WITH normalized AS (
+          SELECT
+            account_id,
+            report_date,
+            CAST(date_trunc('month', CAST(report_date AS timestamp)) AS date) AS report_month,
+            "user",
+            arn,
+            password_enabled = 'TRUE' AS password_enabled,
+            mfa_active = 'TRUE' AS mfa_active,
+            access_key_1_active = 'TRUE' AS access_key_1_active,
+            access_key_1_last_used_region,
+            access_key_1_last_used_service,
+            access_key_2_active = 'TRUE' AS access_key_2_active,
+            access_key_2_last_used_region,
+            access_key_2_last_used_service,
+            cert_1_active = 'TRUE' AS cert_1_active,
+            cert_2_active = 'TRUE' AS cert_2_active,
+            additional_credentials_info,
+            CASE WHEN user_creation_time IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(user_creation_time)) END AS user_creation_dt,
+            CASE WHEN password_last_used IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_last_used)) END AS password_last_used_dt,
+            CASE WHEN password_last_changed IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_last_changed)) END AS password_last_changed_dt,
+            CASE WHEN password_next_rotation IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(password_next_rotation)) END AS password_next_rotation_dt,
+            CASE WHEN access_key_1_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_1_last_rotated)) END AS access_key_1_last_rotated_dt,
+            CASE WHEN access_key_1_last_used_date IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_1_last_used_date)) END AS access_key_1_last_used_dt,
+            CASE WHEN access_key_2_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_2_last_rotated)) END AS access_key_2_last_rotated_dt,
+            CASE WHEN access_key_2_last_used_date IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(access_key_2_last_used_date)) END AS access_key_2_last_used_dt,
+            CASE WHEN cert_1_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(cert_1_last_rotated)) END AS cert_1_last_rotated_dt,
+            CASE WHEN cert_2_last_rotated IN ('N/A', 'no_information', 'not_supported') THEN from_iso8601_timestamp('1970-01-01T00:00:00+00:00') ELSE try(from_iso8601_timestamp(cert_2_last_rotated)) END AS cert_2_last_rotated_dt
+          FROM ${DatabaseName}.iam_credential_report_data
+        )
+        SELECT
+          *,
+          CAST(date_trunc('month', access_key_1_last_used_dt) AS date) AS access_key_1_last_used_month,
+          CAST(date_trunc('month', access_key_2_last_used_dt) AS date) AS access_key_2_last_used_month,
+          CAST(date_trunc('month', password_last_used_dt) AS date) AS password_last_used_month
+        FROM normalized


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

• Add CID IAM credential report collection module

  - Add iam-credential-report data collection module
  - Collect IAM credential reports per linked account
  - Store daily CSV snapshots partitioned by account_id/report_date
  - Add Glue table for Athena access
  - Add Athena saved query for QuickSight view with date normalization
  - Wire module into data collection and read-permission stacks
  - Add linked-account IAM permissions for credential report APIs
  - Document module in data-collection README
  - Fix DeployAccountCollector Fn::Or grouping limit



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
