### PR TITLE
Add eu-south-1 (Milan) to data collection supported regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Make sure you are installing data collection in the same region where you are go
 | Europe (Frankfurt) | eu-central-1 |  :heavy_check_mark: |
 | Europe (Zurich) | eu-central-2 |  |
 | Europe (Stockholm) | eu-north-1 |  :heavy_check_mark: |
-| Europe (Milan) | eu-south-1 |  |
+| Europe (Milan) | eu-south-1 |  :heavy_check_mark: |
 | Europe (Spain) | eu-south-2 |  |
 | Europe (Ireland) | eu-west-1 |  :heavy_check_mark: |
 | Europe (London) | eu-west-2 |  :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Make sure you are installing data collection in the same region where you are go
 | Canada (Central) | ca-central-1 |  :heavy_check_mark: |
 | China (Beijing) | cn-north-1 |  |
 | Europe (Frankfurt) | eu-central-1 |  :heavy_check_mark: |
-| Europe (Zurich) | eu-central-2 |  |
+| Europe (Zurich) | eu-central-2 |  :heavy_check_mark: |
 | Europe (Stockholm) | eu-north-1 |  :heavy_check_mark: |
 | Europe (Milan) | eu-south-1 |  :heavy_check_mark: |
 | Europe (Spain) | eu-south-2 |  |

--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -129,6 +129,7 @@ Mappings:
     ca-central-1:   {CodeBucket: aws-managed-cost-intelligence-dashboards-ca-central-1 }
     eu-central-1:   {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-central-1 }
     eu-north-1:     {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-north-1 }
+    eu-south-1:     {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-south-1 }
     eu-west-1:      {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-west-1 }
     eu-west-2:      {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-west-2 }
     eu-west-3:      {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-west-3 }

--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -128,6 +128,7 @@ Mappings:
     ap-southeast-2: {CodeBucket: aws-managed-cost-intelligence-dashboards-ap-southeast-2 }
     ca-central-1:   {CodeBucket: aws-managed-cost-intelligence-dashboards-ca-central-1 }
     eu-central-1:   {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-central-1 }
+    eu-central-2:   {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-central-2 }
     eu-north-1:     {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-north-1 }
     eu-south-1:     {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-south-1 }
     eu-west-1:      {CodeBucket: aws-managed-cost-intelligence-dashboards-eu-west-1 }


### PR DESCRIPTION
QuickSight is now available in eu-south-1. Adds the region to the RegionMap in deploy-data-collection.yaml and marks it as supported in the README region table.

Note for maintainers: requires an eu-south-1 instance in the LayerBuckets StackSet and a release sync so that
aws-managed-cost-intelligence-dashboards-eu-south-1 serves the code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
