### PR TITLE
fix(lint): skip cfn_nag for module-kiro-user-activity.yaml (Fn::ForEach)

### DIFF
--- a/utils/lint.sh
+++ b/utils/lint.sh
@@ -21,7 +21,7 @@ failure_count=0
 # CKV_AWS_158 - Ensure that CloudWatch Log Group is encrypted by KMS - No need as there no sesible information in the logs
 checkov_skip=CKV_AWS_18,CKV_AWS_117,CKV_AWS_116,CKV_AWS_173,CKV_AWS_195,CKV_SECRET_6,CKV_AWS_115,CKV_AWS_158
 
-export exclude_files=("module-inventory.yaml" "module-pricing.yaml" "module-backup.yaml") # For::Each breaks lint :'(
+export exclude_files=("module-inventory.yaml" "module-pricing.yaml" "module-backup.yaml" "module-kiro-user-activity.yaml") # For::Each breaks lint :'(
 
 yaml_files=$(find "$folder" -type f -name "*.yaml" -exec ls -1t "{}" +;) # ordered by date
 


### PR DESCRIPTION
module-kiro-user-activity.yaml uses Fn::ForEach, which cfn-model 0.6.6 (cfn_nag) cannot parse and crashes on with a TypeError. It was the only For::Each module missing from lint.sh's cfn_nag exclude_files list (module-inventory/pricing/backup are already excluded), so utils/lint.sh reported a spurious 'Failed lints: 1'. Add it to the exclude list for consistent handling; checkov and cfn-lint still run and pass.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
