### PR TITLE
fix(service-quotas): add compressionType=none to Glue table Parameters

### DIFF
--- a/data-collection/deploy/module-service-quotas.yaml
+++ b/data-collection/deploy/module-service-quotas.yaml
@@ -74,6 +74,7 @@ Resources:
         Parameters:
           "use.null.for.invalid.data": "true"
           "classification": "json"
+          "compressionType": "none"
           "UPDATED_BY_CRAWLER": !Sub "${ResourcePrefix}${CFDataName}-Crawler"
         StorageDescriptor:
           Columns:
@@ -137,6 +138,7 @@ Resources:
         Parameters:
           "use.null.for.invalid.data": "true"
           "classification": "json"
+          "compressionType": "none"
           "UPDATED_BY_CRAWLER": !Sub "${ResourcePrefix}${CFDataName}-Crawler"
         StorageDescriptor:
           Columns:


### PR DESCRIPTION
Follows up on #456.

## Problem
On fresh deploys the pre-defined Glue tables were created with `compressionType=null` (missing). The Glue Crawler scanning S3 JSON files detects `compressionType=none` — Glue treats `null` and `none` as different values and refuses to update the table, causing partition registration to fail with a `Cannot merge new columns` warning. The tables get marked deprecated and no partitions are registered.

Two testers reported this issue post-merge of #456. Workaround was deleting the tables and re-running the crawler.

## Fix
Added `"compressionType": "none"` to the Parameters block of both `ServiceQuotasDataTable` and `ServiceQuotasHistoryTable`, matching the pattern already used by `module-inventory.yaml` and `module-cost-anomaly.yaml`.

## Validation
Confirmed by reading Glue table parameters in a test account where the crawler had already set `compressionType=none` — the CFN tables now match from day one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.